### PR TITLE
Update dependencies version - canvas

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "http://github.com/harthur/kittydar.git"
   },
   "dependencies": {
-    "canvas": "1.0.1",
+    "canvas": "^1.0.1",
     "brain": "~0.6.0",
     "hog-descriptor": "~0.5.0",
     "svm": "~0.1.1",


### PR DESCRIPTION
Canvas needs to be the latest version to be able to work with the latest node 
Issue #26
